### PR TITLE
Resolve conflicting sources.list file

### DIFF
--- a/kibana/repo.sls
+++ b/kibana/repo.sls
@@ -5,7 +5,7 @@ kibana-repo:
   pkgrepo.managed:
     - humanname: Kibana Repo
     - name: deb {{ kibana.repo_url }} stable main
-    - file: /etc/apt/sources.list.d/elasticsearch.list
+    - file: /etc/apt/sources.list.d/kibana.list
     - gpgcheck: 1
     - key_url: https://packages.elastic.co/GPG-KEY-elasticsearch
     - require_in:


### PR DESCRIPTION
The current version puts the Kibana repository in `elasticsearch.list`, which conflicts with the [elasticsearch-formula](https://github.com/saltstack-formulas/elasticsearch-formula). This PR moves this repository listing into `kibana.list`, where it will still be read by `apt`, but does not conflict with the Elasticsearch formula.