### PR TITLE
State to install Kibana plugins

### DIFF
--- a/kibana/plugins.sls
+++ b/kibana/plugins.sls
@@ -4,15 +4,15 @@
 {%- set plugins_list = salt['pillar.get']('kibana:plugins', {}) %}
 
 {% if kibana.source  %}
-    {%- set install_path = kibana.sources.installPath ~ '/current' %}
-    {% if kibana.sourceVersion[0] == 5 %}
+    {%- set install_path = kibana.sources.installPath ~ 'current' %}
+    {% if kibana.sourceVersion[0] == '5' %}
         {%- set plugin_bin = 'kibana-plugin' %}
     {% else %}
         {%- set plugin_bin = 'plugin' %}
     {% endif %}
 {% else %}
     {%- set install_path = '/usr/share/kibana' %}
-    {% if kibana.repoVersion == 5 %}
+    {% if kibana.repoVersion == '5' %}
         {%- set plugin_bin = 'kibana-plugin' %}
     {% else %}
         {%- set plugin_bin = 'plugin' %}

--- a/kibana/plugins.sls
+++ b/kibana/plugins.sls
@@ -1,0 +1,32 @@
+{% from "kibana/map.jinja" import kibana with context %}
+
+
+{%- set plugins_list = salt['pillar.get']('kibana:plugins', {}) %}
+
+{% if kibana.source  %}
+    {%- set install_path = kibana.sources.installPath ~ '/current' %}
+    {% if kibana.sourceVersion[0] == 5 %}
+        {%- set plugin_bin = 'kibana-plugin' %}
+    {% else %}
+        {%- set plugin_bin = 'plugin' %}
+    {% endif %}
+{% else %}
+    {%- set install_path = '/usr/share/kibana' %}
+    {% if kibana.repoVersion == 5 %}
+        {%- set plugin_bin = 'kibana-plugin' %}
+    {% else %}
+        {%- set plugin_bin = 'plugin' %}
+    {% endif %}
+{% endif %}
+
+include:
+    - kibana.install
+
+{% for name, repo in plugins_list.items() %}
+kibana-plugin-{{ name }}:
+    cmd.run:
+        - name: {{ install_path }}/bin/{{ plugin_bin }} install -b {{ repo }}
+        - require:
+            - sls: kibana.install
+        - unless: test -x {{ install_path }}/plugins/{{ name }}
+{% endfor %}

--- a/pillar.example
+++ b/pillar.example
@@ -5,3 +5,5 @@ kibana:
   source: false
   config:
     elasticsearch.url: "http://localhost:9200"
+  plugins:
+    x-pack: x-pack


### PR DESCRIPTION
It allows the installation of KIbana plugins that can be specified under ``kibana:plugins`` pillar key (see below an example).

~~~.yaml
kibana:
  ...
  plugins:
    x-pack: https://artifacts.elastic.co/downloads/packs/x-pack/x-pack-5.4.0.zip
    # or
    x-pack: x-pack
~~~

This new state is deeply inspired by [elasticsearch.plugin](https://github.com/saltstack-formulas/elasticsearch-formula/blob/master/elasticsearch/plugins.sls) state.