### PR TITLE
Elastic Kibana Version Scheme Fix

### DIFF
--- a/kibana/config.sls
+++ b/kibana/config.sls
@@ -3,6 +3,7 @@
 
 {% from "kibana/map.jinja" import kibana with context %}
 
+# We directly serialize the config subtree into the YAML file.
 {% if kibana.configfile == '/etc/kibana/kibana.yml' %}
 kibana-create-config-folder:
   file.directory:
@@ -11,8 +12,6 @@ kibana-create-config-folder:
     - user: root
     - group: root
 {% endif %}
-
-# We directly serialize the config subtree into the YAML file.
 kibana-config:
   file.serialize:
     - name: {{ kibana.configfile }}

--- a/kibana/config.sls
+++ b/kibana/config.sls
@@ -3,7 +3,6 @@
 
 {% from "kibana/map.jinja" import kibana with context %}
 
-# We directly serialize the config subtree into the YAML file.
 {% if kibana.configfile == '/etc/kibana/kibana.yml' %}
 kibana-create-config-folder:
   file.directory:
@@ -13,6 +12,7 @@ kibana-create-config-folder:
     - group: root
 {% endif %}
 
+# We directly serialize the config subtree into the YAML file.
 kibana-config:
   file.serialize:
     - name: {{ kibana.configfile }}

--- a/kibana/config.sls
+++ b/kibana/config.sls
@@ -4,6 +4,15 @@
 {% from "kibana/map.jinja" import kibana with context %}
 
 # We directly serialize the config subtree into the YAML file.
+{% if kibana.configfile == '/etc/kibana/kibana.yml' %}
+kibana-create-config-folder:
+  file.directory:
+    - name: /etc/kibana
+    - mode: 755
+    - user: root
+    - group: root
+{% endif %}
+
 kibana-config:
   file.serialize:
     - name: {{ kibana.configfile }}

--- a/kibana/config.sls
+++ b/kibana/config.sls
@@ -3,7 +3,6 @@
 
 {% from "kibana/map.jinja" import kibana with context %}
 
-# We directly serialize the config subtree into the YAML file.
 {% if kibana.configfile == '/etc/kibana/kibana.yml' %}
 kibana-create-config-folder:
   file.directory:
@@ -12,6 +11,8 @@ kibana-create-config-folder:
     - user: root
     - group: root
 {% endif %}
+
+# We directly serialize the config subtree into the YAML file.
 kibana-config:
   file.serialize:
     - name: {{ kibana.configfile }}

--- a/kibana/install.sls
+++ b/kibana/install.sls
@@ -15,4 +15,5 @@ include:
 kibana-pkg:
   pkg.installed:
     - name: {{ kibana.pkg }}
+    - version: {{ kibana.repoVersion }}
 {%- endif %}

--- a/kibana/install.sls
+++ b/kibana/install.sls
@@ -15,5 +15,7 @@ include:
 kibana-pkg:
   pkg.installed:
     - name: {{ kibana.pkg }}
+{% if kibana.repoVersion[0] == '5' %}
     - version: {{ kibana.repoVersion }}
+{% endif %}
 {%- endif %}

--- a/kibana/install.sls
+++ b/kibana/install.sls
@@ -15,7 +15,5 @@ include:
 kibana-pkg:
   pkg.installed:
     - name: {{ kibana.pkg }}
-{% if kibana.repoVersion[0] == '5' %}
     - version: {{ kibana.repoVersion }}
-{% endif %}
 {%- endif %}

--- a/kibana/versions.yaml
+++ b/kibana/versions.yaml
@@ -1,5 +1,5 @@
 
-{% if salt['pillar.get']('kibana:repoVersion[0]' == '5') %}
+{% if salt['pillar.get']('kibana:repoVersion|startswith == '5') %}
 {{ salt['pillar.get']('kibana:repoVersion') }}:
   repo_url: https://artifacts.elastic.co/packages/5.x/apt
   configfile: /etc/kibana/kibana.yml

--- a/kibana/versions.yaml
+++ b/kibana/versions.yaml
@@ -1,8 +1,9 @@
-{% if kibana.repoVersion[0] == '5' %}
-{{ kibana.repoVersion }}:
+'5.5.1':
   repo_url: https://artifacts.elastic.co/packages/5.x/apt
   configfile: /etc/kibana/kibana.yml
-{% endif %}
+'5':
+  repo_url: https://artifacts.elastic.co/packages/5.x/apt
+  configfile: /etc/kibana/kibana.yml
 '4.6':
   repo_url: http://packages.elastic.co/kibana/4.6/debian
   configfile: /opt/kibana/config/kibana.yml

--- a/kibana/versions.yaml
+++ b/kibana/versions.yaml
@@ -1,6 +1,6 @@
 
 {% if salt['pillar.get']('kibana:repoVersion[0]' == '5') %}
-{{ salt['pillar.get']('kibana:repoVersion']) }}:
+{{ salt['pillar.get']('kibana:repoVersion') }}:
   repo_url: https://artifacts.elastic.co/packages/5.x/apt
   configfile: /etc/kibana/kibana.yml
 {% endif %}

--- a/kibana/versions.yaml
+++ b/kibana/versions.yaml
@@ -1,3 +1,6 @@
+'5.5.1':
+  repo_url: https://artifacts.elastic.co/packages/5.x/apt
+  configfile: /etc/kibana/kibana.yml
 '5':
   repo_url: https://artifacts.elastic.co/packages/5.x/apt
   configfile: /etc/kibana/kibana.yml

--- a/kibana/versions.yaml
+++ b/kibana/versions.yaml
@@ -1,5 +1,5 @@
 
-{% if salt['pillar.get']('kibana:repoVersion|startswith == '5') %}
+{% if salt['pillar.get']('kibana:repoVersion.startswith('5')) %}
 {{ salt['pillar.get']('kibana:repoVersion') }}:
   repo_url: https://artifacts.elastic.co/packages/5.x/apt
   configfile: /etc/kibana/kibana.yml

--- a/kibana/versions.yaml
+++ b/kibana/versions.yaml
@@ -1,7 +1,6 @@
-{% from "kibana/map.jinja" import kibana with context %}
 
-{% if kibana.repoVersion[0] == '5' %}
-{{ kibana.repoVersion }}:
+{% if salt['pillar.get']('kibana:repoVersion[0]' == '5' %}
+{{ salt['pillar.get']('kibana:repoVersion'] }}:
   repo_url: https://artifacts.elastic.co/packages/5.x/apt
   configfile: /etc/kibana/kibana.yml
 {% endif %}

--- a/kibana/versions.yaml
+++ b/kibana/versions.yaml
@@ -1,6 +1,6 @@
 
-{% if salt['pillar.get']('kibana:repoVersion[0]' == '5' %}
-{{ salt['pillar.get']('kibana:repoVersion'] }}:
+{% if salt['pillar.get']('kibana:repoVersion[0]' == '5') %}
+{{ salt['pillar.get']('kibana:repoVersion']) }}:
   repo_url: https://artifacts.elastic.co/packages/5.x/apt
   configfile: /etc/kibana/kibana.yml
 {% endif %}

--- a/kibana/versions.yaml
+++ b/kibana/versions.yaml
@@ -1,9 +1,8 @@
-'5.5.1':
+{% if kibana.repoVersion[0] == '5' %}
+{{ kibana.repoVersion }}:
   repo_url: https://artifacts.elastic.co/packages/5.x/apt
   configfile: /etc/kibana/kibana.yml
-'5':
-  repo_url: https://artifacts.elastic.co/packages/5.x/apt
-  configfile: /etc/kibana/kibana.yml
+{% endif %}
 '4.6':
   repo_url: http://packages.elastic.co/kibana/4.6/debian
   configfile: /opt/kibana/config/kibana.yml

--- a/kibana/versions.yaml
+++ b/kibana/versions.yaml
@@ -1,3 +1,5 @@
+{% from "kibana/map.jinja" import kibana with context %}
+
 {% if kibana.repoVersion[0] == '5' %}
 {{ kibana.repoVersion }}:
   repo_url: https://artifacts.elastic.co/packages/5.x/apt


### PR DESCRIPTION
Hallo

Sorry for the confusion. I opened a pull request at johnkeates formula and not here.

first of all, there is a problem regarding the versions.yaml. It is a dict. I cannot install 5.5.1 cause it has only version "5" in their dict. I had to add "5.5.1", I know this is not a clean solution, but I could not figure out, how I could do a "match only first number of repoVersion Variable and check if dict exists".

I also added - version: {{ kibana.repoVersion }} in the install.sls

proof
[INFO ] Executing command ['systemd-run', '--scope', 'apt-get', '-q', '-y', '-o', 'DPkg::Options::=--force-confold', '-o', 'DPkg::Options::=--force-confdef', 'install', 'kibana=5.5.1'] in directory '/root'