### PR TITLE
Import YAML with context

### DIFF
--- a/kibana/map.jinja
+++ b/kibana/map.jinja
@@ -2,8 +2,8 @@
 # vim: ft=jinja
 
 {## Start with  defaults from defaults.sls ##}
-{% import_yaml 'kibana/defaults.yaml' as default_settings %}
-{%- import_yaml 'kibana/versions.yaml' as version_map %}
+{% import_yaml 'kibana/defaults.yaml' as default_settings with context %}
+{%- import_yaml 'kibana/versions.yaml' as version_map with context %}
 
 {##
 Setup variable using grains['os_family'] based logic, only add key:values here


### PR DESCRIPTION
While switching to Salt v3003, I notice this error, having issues to find the `salt` variable. 
Let's import `with context`, so we can fix this.

```
---
local:
    Data failed to compile:
----------
    Rendering SLS 'base:kibana.install' failed: Jinja variable 'salt' is undefined
/var/cache/salt/minion/files/base/kibana/versions.yaml(2):
---
# take a look at github pull request #16 before editing here
{% if(salt['pillar.get']('kibana:repoVersion')) %}    <======================
  {% set versionRepo = salt['pillar.get']('kibana:repoVersion') %}
  {% if versionRepo.startswith('5.') %}
{{ versionRepo }}:
  repo_url: https://artifacts.elastic.co/packages/5.x/apt
  configfile: /etc/kibana/kibana.yml
[...]
---
----------
    Rendering SLS 'base:kibana.config' failed: Jinja variable 'salt' is undefined
/var/cache/salt/minion/files/base/kibana/versions.yaml(2):
---
# take a look at github pull request #16 before editing here
{% if(salt['pillar.get']('kibana:repoVersion')) %}    <======================
  {% set versionRepo = salt['pillar.get']('kibana:repoVersion') %}
  {% if versionRepo.startswith('5.') %}
{{ versionRepo }}:
  repo_url: https://artifacts.elastic.co/packages/5.x/apt
  configfile: /etc/kibana/kibana.yml
[...]
---
----------
    Rendering SLS 'base:kibana.service' failed: Jinja variable 'salt' is undefined
/var/cache/salt/minion/files/base/kibana/versions.yaml(2):
---
# take a look at github pull request #16 before editing here
{% if(salt['pillar.get']('kibana:repoVersion')) %}    <======================
  {% set versionRepo = salt['pillar.get']('kibana:repoVersion') %}
  {% if versionRepo.startswith('5.') %}
{{ versionRepo }}:
  repo_url: https://artifacts.elastic.co/packages/5.x/apt
  configfile: /etc/kibana/kibana.yml
[...]
---
```